### PR TITLE
#35: Fix hotkey registration bugs and add integration tests

### DIFF
--- a/TheGrammar.sln
+++ b/TheGrammar.sln
@@ -9,22 +9,49 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C14B5A29-C87
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{C7C51A4A-3313-4359-86CD-DDE3F7539B7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheGrammar.Tests", "tests\TheGrammar.Tests\TheGrammar.Tests.csproj", "{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Debug|x64.Build.0 = Debug|Any CPU
+		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Debug|x86.Build.0 = Debug|Any CPU
 		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Release|x64.ActiveCfg = Release|Any CPU
+		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Release|x64.Build.0 = Release|Any CPU
+		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Release|x86.ActiveCfg = Release|Any CPU
+		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C}.Release|x86.Build.0 = Release|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Debug|x64.Build.0 = Debug|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Debug|x86.Build.0 = Debug|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Release|x64.ActiveCfg = Release|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Release|x64.Build.0 = Release|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7CFCE4BC-B610-4C9B-949C-431374FF1C7C} = {C14B5A29-C87F-45C5-9CB2-6F3744BA6AD3}
+		{E9DAAA0F-94C0-48A4-98E8-18AF3FF8325E} = {C7C51A4A-3313-4359-86CD-DDE3F7539B7D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A544F07-2B07-4774-BCD3-2C00E5247864}

--- a/src/TheGrammar/Features/HotKeys/GlobalKeyBindingState.cs
+++ b/src/TheGrammar/Features/HotKeys/GlobalKeyBindingState.cs
@@ -6,12 +6,14 @@ namespace TheGrammar.Features.HotKeys;
 public interface IGlobalKeyBindingState
 {
     Dictionary<int, (Keys LeftKey, Keys RightKey, string Prompt)> KeyBindings { get; }
+    bool IsInitialized { get; }
     Task InitAsync();
 }
 
 public class GlobalKeyBindingState : IGlobalKeyBindingState
 {
     public Dictionary<int, (Keys LeftKey, Keys RightKey, string Prompt)> KeyBindings { get; private set; } = new();
+    public bool IsInitialized { get; private set; }
 
     private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
 
@@ -35,5 +37,6 @@ public class GlobalKeyBindingState : IGlobalKeyBindingState
         }
 
         KeyBindings = keyBindings;
+        IsInitialized = true;
     }
 }

--- a/src/TheGrammar/Features/HotKeys/GlobalKeyBindingState.cs
+++ b/src/TheGrammar/Features/HotKeys/GlobalKeyBindingState.cs
@@ -5,13 +5,13 @@ namespace TheGrammar.Features.HotKeys;
 
 public interface IGlobalKeyBindingState
 {
-    Dictionary<(Keys, Keys), string> KeyBindings { get; }
+    Dictionary<int, (Keys LeftKey, Keys RightKey, string Prompt)> KeyBindings { get; }
     Task InitAsync();
 }
 
 public class GlobalKeyBindingState : IGlobalKeyBindingState
 {
-    public Dictionary<(Keys, Keys), string> KeyBindings { get; private set; } = new();
+    public Dictionary<int, (Keys LeftKey, Keys RightKey, string Prompt)> KeyBindings { get; private set; } = new();
 
     private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
 
@@ -24,14 +24,16 @@ public class GlobalKeyBindingState : IGlobalKeyBindingState
 
     public async Task InitAsync()
     {
-        using var scope = _dbContextFactory.CreateDbContext().Database.BeginTransaction();
-        var prompts = await _dbContextFactory.CreateDbContext().Prompts.ToListAsync();
+        using var context = _dbContextFactory.CreateDbContext();
+        var prompts = await context.Prompts.ToListAsync();
 
-        KeyBindings = new Dictionary<(Keys, Keys), string>();
+        var keyBindings = new Dictionary<int, (Keys LeftKey, Keys RightKey, string Prompt)>();
 
         foreach (var prompt in prompts)
         {
-            KeyBindings.Add((prompt.RightKey, prompt.LeftKey), prompt.Promt);
+            keyBindings.Add(prompt.Id, (prompt.LeftKey, prompt.RightKey, prompt.Promt));
         }
+
+        KeyBindings = keyBindings;
     }
 }

--- a/src/TheGrammar/Features/HotKeys/Services/HotKeyListener.cs
+++ b/src/TheGrammar/Features/HotKeys/Services/HotKeyListener.cs
@@ -6,6 +6,7 @@ namespace TheGrammar.Features.HotKeys.Services
     public class HotKeyListener : NativeWindow, IDisposable
     {
         private const int WM_HOTKEY = 0x0312;
+        private const int WM_INPUTLANGCHANGE = 0x0051;
 
         [Flags]
         private enum FsModifiers : uint
@@ -25,6 +26,10 @@ namespace TheGrammar.Features.HotKeys.Services
 
         private readonly IGlobalKeyBindingState _keyBindingState;
         private readonly IProcessInputEventService _processInputEventService;
+
+        // promptId -> the OS hotkey id currently registered for it
+        private readonly Dictionary<int, int> _promptIdToHotkeyId = new();
+        // OS hotkey id -> prompt text, used to resolve WM_HOTKEY messages
         private readonly Dictionary<int, string> _idToPrompt = new();
         private int _nextId = 1;
 
@@ -41,18 +46,9 @@ namespace TheGrammar.Features.HotKeys.Services
 
         public void RegisterAll()
         {
-            foreach (var binding in _keyBindingState.KeyBindings)
+            foreach (var (promptId, binding) in _keyBindingState.KeyBindings)
             {
-                var (key, modifiers) = binding.Key;
-                var prompt = binding.Value;
-                var id = _nextId++;
-
-                var fs = ToFsModifiers(modifiers) | FsModifiers.NoRepeat;
-
-                if (RegisterHotKey(Handle, id, (uint)fs, (uint)key))
-                {
-                    _idToPrompt[id] = prompt;
-                }
+                Register(promptId, binding.RightKey, binding.LeftKey, binding.Prompt);
             }
         }
 
@@ -63,6 +59,35 @@ namespace TheGrammar.Features.HotKeys.Services
                 UnregisterHotKey(Handle, id);
             }
             _idToPrompt.Clear();
+            _promptIdToHotkeyId.Clear();
+        }
+
+        // Registers (or replaces) the hotkey for a single prompt without touching any other
+        // currently-registered hotkey.
+        public void Register(int promptId, Keys key, Keys modifiers, string prompt)
+        {
+            if (_promptIdToHotkeyId.TryGetValue(promptId, out var previousHotkeyId))
+            {
+                UnregisterHotKey(Handle, previousHotkeyId);
+                _idToPrompt.Remove(previousHotkeyId);
+                _promptIdToHotkeyId.Remove(promptId);
+            }
+
+            var id = _nextId++;
+            var fs = ToFsModifiers(modifiers) | FsModifiers.NoRepeat;
+
+            if (RegisterHotKey(Handle, id, (uint)fs, (uint)key))
+            {
+                _idToPrompt[id] = prompt;
+                _promptIdToHotkeyId[promptId] = id;
+            }
+        }
+
+        // Exposed for integration tests to assert on registration state without reaching into
+        // private fields via reflection.
+        internal int? TryGetHotkeyId(int promptId)
+        {
+            return _promptIdToHotkeyId.TryGetValue(promptId, out var id) ? id : null;
         }
 
         private static FsModifiers ToFsModifiers(Keys modifiers)
@@ -87,6 +112,14 @@ namespace TheGrammar.Features.HotKeys.Services
                     return;
                 }
             }
+            else if (m.Msg == WM_INPUTLANGCHANGE)
+            {
+                // The scan code RegisterHotKey binds to is resolved using the keyboard layout
+                // active at registration time. When the user switches layouts, previously
+                // registered hotkeys keep firing on the old physical key position unless they
+                // are re-registered so Windows recomputes the mapping under the new layout.
+                Refresh();
+            }
             base.WndProc(ref m);
         }
 
@@ -95,7 +128,7 @@ namespace TheGrammar.Features.HotKeys.Services
             UnregisterAll();
             RegisterAll();
         }
-        
+
         public void Dispose()
         {
             UnregisterAll();

--- a/src/TheGrammar/Features/HotKeys/Services/HotKeyListener.cs
+++ b/src/TheGrammar/Features/HotKeys/Services/HotKeyListener.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using Serilog;
 using TheGrammar.Features.HotKeys.Events;
 
 namespace TheGrammar.Features.HotKeys.Services
@@ -14,7 +15,6 @@ namespace TheGrammar.Features.HotKeys.Services
             Alt = 0x0001,
             Control = 0x0002,
             Shift = 0x0004,
-            Win = 0x0008,
             NoRepeat = 0x4000
         }
 
@@ -29,9 +29,17 @@ namespace TheGrammar.Features.HotKeys.Services
 
         // promptId -> the OS hotkey id currently registered for it
         private readonly Dictionary<int, int> _promptIdToHotkeyId = new();
+        // promptId -> the key combination currently registered for it, so Register can tell
+        // whether a re-registration actually changes the combination or is just a text edit
+        private readonly Dictionary<int, (Keys Key, Keys Modifiers)> _promptIdToBinding = new();
         // OS hotkey id -> prompt text, used to resolve WM_HOTKEY messages
         private readonly Dictionary<int, string> _idToPrompt = new();
         private int _nextId = 1;
+        private bool _disposed;
+
+        // Exposed so tests can force a clipboard read failure without relying on the real,
+        // hard-to-simulate CLIPBRD_E_CANT_OPEN condition.
+        internal Func<string> ClipboardTextProvider { get; set; } = Clipboard.GetText;
 
         public HotKeyListener(
             IGlobalKeyBindingState keyBindingState,
@@ -44,11 +52,21 @@ namespace TheGrammar.Features.HotKeys.Services
             CreateHandle(cp);
         }
 
-        public void RegisterAll()
+        public void RegisterAll() => RegisterAll(withRetry: true);
+
+        private void RegisterAll(bool withRetry)
         {
+            ThrowIfDisposed();
+
+            if (!_keyBindingState.IsInitialized)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(GlobalKeyBindingState)}.{nameof(GlobalKeyBindingState.InitAsync)}() must complete before {nameof(RegisterAll)}() is called, otherwise hotkeys would silently register as empty.");
+            }
+
             foreach (var (promptId, binding) in _keyBindingState.KeyBindings)
             {
-                Register(promptId, binding.RightKey, binding.LeftKey, binding.Prompt);
+                Register(promptId, key: binding.RightKey, modifiers: binding.LeftKey, prompt: binding.Prompt, withRetry: withRetry);
             }
         }
 
@@ -60,27 +78,49 @@ namespace TheGrammar.Features.HotKeys.Services
             }
             _idToPrompt.Clear();
             _promptIdToHotkeyId.Clear();
+            _promptIdToBinding.Clear();
         }
 
+        public bool Register(int promptId, Keys key, Keys modifiers, string prompt) =>
+            Register(promptId, key, modifiers, prompt, withRetry: true);
+
         // Registers (or replaces) the hotkey for a single prompt without touching any other
-        // currently-registered hotkey.
-        public void Register(int promptId, Keys key, Keys modifiers, string prompt)
+        // currently-registered hotkey. The new combination is registered before the old one is
+        // torn down, so a failed re-registration leaves the previous, working hotkey intact
+        // instead of dropping the prompt's hotkey entirely. If the combination is unchanged from
+        // what's already registered (e.g. only the prompt text was edited), the OS registration
+        // is left untouched entirely - re-registering the same combination under a new id would
+        // fail, since the old id still owns it.
+        private bool Register(int promptId, Keys key, Keys modifiers, string prompt, bool withRetry)
         {
-            if (_promptIdToHotkeyId.TryGetValue(promptId, out var previousHotkeyId))
+            ThrowIfDisposed();
+
+            if (_promptIdToBinding.TryGetValue(promptId, out var currentBinding)
+                && currentBinding.Key == key && currentBinding.Modifiers == modifiers
+                && _promptIdToHotkeyId.TryGetValue(promptId, out var currentHotkeyId))
             {
-                UnregisterHotKey(Handle, previousHotkeyId);
-                _idToPrompt.Remove(previousHotkeyId);
-                _promptIdToHotkeyId.Remove(promptId);
+                _idToPrompt[currentHotkeyId] = prompt;
+                return true;
             }
 
             var id = _nextId++;
             var fs = ToFsModifiers(modifiers) | FsModifiers.NoRepeat;
 
-            if (RegisterHotKeyWithRetry(id, fs, key))
+            if (!RegisterHotKeyWithRetry(id, fs, key, withRetry, promptId, prompt))
             {
-                _idToPrompt[id] = prompt;
-                _promptIdToHotkeyId[promptId] = id;
+                return false;
             }
+
+            if (_promptIdToHotkeyId.TryGetValue(promptId, out var previousHotkeyId))
+            {
+                UnregisterHotKey(Handle, previousHotkeyId);
+                _idToPrompt.Remove(previousHotkeyId);
+            }
+
+            _idToPrompt[id] = prompt;
+            _promptIdToHotkeyId[promptId] = id;
+            _promptIdToBinding[promptId] = (key, modifiers);
+            return true;
         }
 
         // On startup, a previous instance of the app may have just been killed (see
@@ -89,10 +129,14 @@ namespace TheGrammar.Features.HotKeys.Services
         // so the first RegisterHotKey call can transiently fail with ERROR_HOTKEY_ALREADY_REGISTERED
         // even though the owning process is already gone. A few short retries clear this up
         // reliably without meaningfully slowing down the case where the key really is taken.
-        private bool RegisterHotKeyWithRetry(int id, FsModifiers fs, Keys key)
+        // Retries are skipped (withRetry: false) on the Refresh path: Refresh already tore down
+        // every registration on this window, so there's no stale-instance race to wait out, and
+        // Refresh runs on the UI thread inside WndProc where Thread.Sleep would stall the message pump.
+        private bool RegisterHotKeyWithRetry(int id, FsModifiers fs, Keys key, bool withRetry, int promptId, string prompt)
         {
-            const int maxAttempts = 5;
+            var maxAttempts = withRetry ? 5 : 1;
             const int delayMs = 50;
+            var lastWin32Error = 0;
 
             for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
@@ -101,11 +145,17 @@ namespace TheGrammar.Features.HotKeys.Services
                     return true;
                 }
 
+                lastWin32Error = Marshal.GetLastWin32Error();
+
                 if (attempt < maxAttempts)
                 {
                     Thread.Sleep(delayMs);
                 }
             }
+
+            Log.Warning(
+                "Failed to register hotkey for prompt {Prompt} (promptId: {PromptId}, key: {Key}, modifiers: {Modifiers}, win32Error: {Win32Error})",
+                prompt, promptId, key, fs, lastWin32Error);
 
             return false;
         }
@@ -115,6 +165,34 @@ namespace TheGrammar.Features.HotKeys.Services
         internal int? TryGetHotkeyId(int promptId)
         {
             return _promptIdToHotkeyId.TryGetValue(promptId, out var id) ? id : null;
+        }
+
+        // Internal (rather than private) so tests can exercise this exact code path directly -
+        // the OS message pump swallows exceptions escaping a real WndProc, which makes it
+        // impossible to observe clipboard-failure handling through the full Win32 round trip.
+        // Returns whether id resolved to a registered prompt.
+        internal bool TriggerHotkey(int id)
+        {
+            ThrowIfDisposed();
+
+            if (!_idToPrompt.TryGetValue(id, out var prompt))
+            {
+                return false;
+            }
+
+            string userInput;
+            try
+            {
+                userInput = ClipboardTextProvider();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to read clipboard text for hotkey (prompt: {Prompt})", prompt);
+                return true;
+            }
+
+            _processInputEventService.TriggerProcessStart(new ProcessStartDto(userInput, prompt));
+            return true;
         }
 
         private static FsModifiers ToFsModifiers(Keys modifiers)
@@ -130,18 +208,15 @@ namespace TheGrammar.Features.HotKeys.Services
         {
             if (m.Msg == WM_HOTKEY)
             {
-                var id = m.WParam.ToInt32();
-                if (_idToPrompt.TryGetValue(id, out var prompt))
+                if (TriggerHotkey(m.WParam.ToInt32()))
                 {
-                    var userInput = Clipboard.GetText();
-                    _processInputEventService.TriggerProcessStart(
-                        new ProcessStartDto(userInput, prompt));
                     return;
                 }
             }
             else if (m.Msg == WM_INPUTLANGCHANGE)
             {
-                // The scan code RegisterHotKey binds to is resolved using the keyboard layout
+                // RegisterHotKey's vk parameter is a virtual-key code, not a scan code, and which
+                // physical key produces a given virtual-key is resolved using the keyboard layout
                 // active at registration time. When the user switches layouts, previously
                 // registered hotkeys keep firing on the old physical key position unless they
                 // are re-registered so Windows recomputes the mapping under the new layout.
@@ -152,14 +227,31 @@ namespace TheGrammar.Features.HotKeys.Services
 
         public void Refresh()
         {
+            ThrowIfDisposed();
+
             UnregisterAll();
-            RegisterAll();
+            RegisterAll(withRetry: false);
         }
 
         public void Dispose()
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             UnregisterAll();
             DestroyHandle();
+            _disposed = true;
+            GC.SuppressFinalize(this);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(HotKeyListener));
+            }
         }
     }
 }

--- a/src/TheGrammar/Features/HotKeys/Services/HotKeyListener.cs
+++ b/src/TheGrammar/Features/HotKeys/Services/HotKeyListener.cs
@@ -76,11 +76,38 @@ namespace TheGrammar.Features.HotKeys.Services
             var id = _nextId++;
             var fs = ToFsModifiers(modifiers) | FsModifiers.NoRepeat;
 
-            if (RegisterHotKey(Handle, id, (uint)fs, (uint)key))
+            if (RegisterHotKeyWithRetry(id, fs, key))
             {
                 _idToPrompt[id] = prompt;
                 _promptIdToHotkeyId[promptId] = id;
             }
+        }
+
+        // On startup, a previous instance of the app may have just been killed (see
+        // SquirrelHooks.OnAppRun) while still holding these exact hotkeys. Windows does not
+        // release a terminated process's hotkey registrations synchronously with process exit,
+        // so the first RegisterHotKey call can transiently fail with ERROR_HOTKEY_ALREADY_REGISTERED
+        // even though the owning process is already gone. A few short retries clear this up
+        // reliably without meaningfully slowing down the case where the key really is taken.
+        private bool RegisterHotKeyWithRetry(int id, FsModifiers fs, Keys key)
+        {
+            const int maxAttempts = 5;
+            const int delayMs = 50;
+
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                if (RegisterHotKey(Handle, id, (uint)fs, (uint)key))
+                {
+                    return true;
+                }
+
+                if (attempt < maxAttempts)
+                {
+                    Thread.Sleep(delayMs);
+                }
+            }
+
+            return false;
         }
 
         // Exposed for integration tests to assert on registration state without reaching into

--- a/src/TheGrammar/Features/Prompts/Components/AddPromptDialog.razor.cs
+++ b/src/TheGrammar/Features/Prompts/Components/AddPromptDialog.razor.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using TheGrammar.Features.HotKeys;
+using TheGrammar.Features.HotKeys.Services;
 using TheGrammar.Domain;
 
 namespace TheGrammar.Features.Prompts.Components;
@@ -16,6 +17,7 @@ public partial class AddPromptDialog
     [Inject]  public PromptRepository PromptRepository { get; set; } = null!;
     [Inject] public ISnackbar Snackbar { get; set; } = null!;
     [Inject] public IGlobalKeyBindingState KeyBindingState { get; set; } = null!;
+    [Inject] public HotKeyListener HotKeyListener { get; set; } = null!;
 
     private static List<Keys> PossibleKeys => Enum.GetValues(typeof(Keys)).Cast<Keys>().Where(k => (int)k >= 65 && (int)k <= 90 || (int)k >= 112 && (int)k <= 123).ToList();
     async Task Submit()
@@ -31,6 +33,7 @@ public partial class AddPromptDialog
 
             await PromptRepository.AddPromptAsync(prompt);
             await KeyBindingState.InitAsync();
+            HotKeyListener.Register(prompt.Id, prompt.RightKey, prompt.LeftKey, prompt.Promt);
             Snackbar.Add($"Added prompt: {prompt}", Severity.Success);
             MudDialog!.Close(DialogResult.Ok(true));
         }

--- a/src/TheGrammar/Features/Prompts/Components/AddPromptDialog.razor.cs
+++ b/src/TheGrammar/Features/Prompts/Components/AddPromptDialog.razor.cs
@@ -33,8 +33,15 @@ public partial class AddPromptDialog
 
             await PromptRepository.AddPromptAsync(prompt);
             await KeyBindingState.InitAsync();
-            HotKeyListener.Register(prompt.Id, prompt.RightKey, prompt.LeftKey, prompt.Promt);
-            Snackbar.Add($"Added prompt: {prompt}", Severity.Success);
+            var registered = HotKeyListener.Register(prompt.Id, key: prompt.RightKey, modifiers: prompt.LeftKey, prompt: prompt.Promt);
+            if (registered)
+            {
+                Snackbar.Add($"Added prompt: {prompt}", Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add($"Added prompt, but the hotkey {prompt} is already in use by another shortcut", Severity.Warning);
+            }
             MudDialog!.Close(DialogResult.Ok(true));
         }
         catch (Exception ex)

--- a/src/TheGrammar/Features/Prompts/Components/PromptView.razor.cs
+++ b/src/TheGrammar/Features/Prompts/Components/PromptView.razor.cs
@@ -22,8 +22,15 @@ public partial class PromptView
         {
             await PromptRepository.UpdatePromptAsync(prompt);
             await KeyBindingState.InitAsync();
-            HotKeyListener.Register(prompt.Id, prompt.RightKey, prompt.LeftKey, prompt.Promt);
-            Snackbar.Add($"Updated prompt: {prompt}", Severity.Success);
+            var registered = HotKeyListener.Register(prompt.Id, key: prompt.RightKey, modifiers: prompt.LeftKey, prompt: prompt.Promt);
+            if (registered)
+            {
+                Snackbar.Add($"Updated prompt: {prompt}", Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add($"Updated prompt, but the hotkey {prompt} is already in use by another shortcut", Severity.Warning);
+            }
         }
         catch (Exception ex)
         {

--- a/src/TheGrammar/Features/Prompts/Components/PromptView.razor.cs
+++ b/src/TheGrammar/Features/Prompts/Components/PromptView.razor.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using TheGrammar.Domain;
+using TheGrammar.Features.HotKeys;
+using TheGrammar.Features.HotKeys.Services;
 
 namespace TheGrammar.Features.Prompts.Components;
 
@@ -8,6 +10,8 @@ public partial class PromptView
 {
     [CascadingParameter] public PromptRepository PromptRepository { get; set; } = null!;
     [Inject] public ISnackbar Snackbar { get; set; } = null!;
+    [Inject] public IGlobalKeyBindingState KeyBindingState { get; set; } = null!;
+    [Inject] public HotKeyListener HotKeyListener { get; set; } = null!;
     [Parameter] public List<Prompt> Prompts { get; set; } = new List<Prompt>();
 
     private static List<Keys> PossibleKeys => Enum.GetValues(typeof(Keys)).Cast<Keys>().Where(k => (int)k >= 65 && (int)k <= 90 || (int)k >= 112 && (int)k <= 123).ToList();
@@ -17,6 +21,8 @@ public partial class PromptView
         try
         {
             await PromptRepository.UpdatePromptAsync(prompt);
+            await KeyBindingState.InitAsync();
+            HotKeyListener.Register(prompt.Id, prompt.RightKey, prompt.LeftKey, prompt.Promt);
             Snackbar.Add($"Updated prompt: {prompt}", Severity.Success);
         }
         catch (Exception ex)

--- a/src/TheGrammar/Features/Prompts/Prompts.razor.cs
+++ b/src/TheGrammar/Features/Prompts/Prompts.razor.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using TheGrammar.Domain;
-using TheGrammar.Features.HotKeys.Services;
 using TheGrammar.Features.Prompts.Components;
 
 namespace TheGrammar.Features.Prompts;
@@ -10,7 +9,6 @@ public partial class Prompts
 {
     [Inject] public IDialogService DialogService { get; set; } = null!;
     [Inject] public PromptRepository PromptRepository { get; set; } = null!;
-    [Inject] public HotKeyListener HotKeyListener { get; set; } = null!;
 
     private List<Prompt> prompts = new();
     protected override async Task OnInitializedAsync()
@@ -35,7 +33,5 @@ public partial class Prompts
         {
             await LoadPrompts();
         }
-        
-        HotKeyListener.Refresh();
     }
 }

--- a/src/TheGrammar/SquirrelHooks.cs
+++ b/src/TheGrammar/SquirrelHooks.cs
@@ -25,6 +25,7 @@ public class SquirrelHooks
             if (process.Id != Environment.ProcessId)
             {
                 process.Kill();
+                process.WaitForExit(5000);
             }
         }
 

--- a/src/TheGrammar/TheGrammar.csproj
+++ b/src/TheGrammar/TheGrammar.csproj
@@ -42,6 +42,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="TheGrammar.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/tests/TheGrammar.Tests/HotKeyListenerIntegrationTests.cs
+++ b/tests/TheGrammar.Tests/HotKeyListenerIntegrationTests.cs
@@ -1,0 +1,265 @@
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TheGrammar.Database;
+using TheGrammar.Domain;
+using TheGrammar.Features.HotKeys;
+using TheGrammar.Features.HotKeys.Events;
+using TheGrammar.Features.HotKeys.Services;
+using TheGrammar.Features.Prompts;
+
+namespace TheGrammar.Tests;
+
+// These tests exercise the real Win32 RegisterHotKey/UnregisterHotKey calls and a real SQLite
+// database, since the bugs being guarded against here were in that exact integration, not in any
+// single isolated unit. Hotkeys are simulated by posting WM_HOTKEY / WM_INPUTLANGCHANGE directly
+// to the listener's window rather than simulating real keystrokes: real global hotkeys are a
+// system-wide, session-shared resource, so driving them via SendInput would be flaky in CI
+// (focus/session quirks, and collisions with whatever else is registered on the machine).
+// Uncommon modifier+key combinations (Ctrl+Alt+Shift+F13/F14/F15) are used to minimize the
+// (already small) chance of colliding with a real shortcut on the test machine.
+[Collection("HotKeyListener (not parallel - global OS hotkey state)")]
+public class HotKeyListenerIntegrationTests : IDisposable
+{
+  private const int WM_HOTKEY = 0x0312;
+  private const int WM_INPUTLANGCHANGE = 0x0051;
+
+  [DllImport("user32.dll", SetLastError = true)]
+  private static extern bool PostMessage(nint hWnd, int msg, nint wParam, nint lParam);
+
+  private readonly string _dbPath;
+  private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
+  private readonly IGlobalKeyBindingState _keyBindingState;
+  private readonly PromptRepository _promptRepository;
+
+  public HotKeyListenerIntegrationTests()
+  {
+    _dbPath = Path.Combine(Path.GetTempPath(), $"thegrammar-tests-{Guid.NewGuid():N}.db");
+
+    var services = new ServiceCollection();
+    services.AddDbContextFactory<ApplicationDbContext>(options => options.UseSqlite($"Data Source={_dbPath}"));
+    var provider = services.BuildServiceProvider();
+
+    _dbContextFactory = provider.GetRequiredService<IDbContextFactory<ApplicationDbContext>>();
+    using (var context = _dbContextFactory.CreateDbContext())
+    {
+      context.Database.EnsureCreated();
+    }
+
+    _keyBindingState = new GlobalKeyBindingState(_dbContextFactory);
+    _promptRepository = new PromptRepository(_dbContextFactory);
+  }
+
+  public void Dispose()
+  {
+    // Microsoft.Data.Sqlite pools native connections behind the scenes; without clearing the
+    // pool first, the temp db file can still be locked here even though every DbContext using
+    // it has already been disposed.
+    SqliteConnection.ClearAllPools();
+
+    if (File.Exists(_dbPath))
+    {
+      File.Delete(_dbPath);
+    }
+  }
+
+  private static T RunOnSta<T>(Func<T> action)
+  {
+    T result = default!;
+    Exception? failure = null;
+
+    var thread = new Thread(() =>
+    {
+      try
+      {
+        result = action();
+      }
+      catch (Exception ex)
+      {
+        failure = ex;
+      }
+    });
+    thread.SetApartmentState(ApartmentState.STA);
+    thread.Start();
+    thread.Join();
+
+    if (failure is not null)
+    {
+      throw new Exception("STA thread failed", failure);
+    }
+
+    return result;
+  }
+
+  private static void PostHotkey(nint handle, int hotkeyId)
+  {
+    PostMessage(handle, WM_HOTKEY, hotkeyId, 0);
+    Application.DoEvents();
+  }
+
+  private static void PostLayoutChange(nint handle)
+  {
+    PostMessage(handle, WM_INPUTLANGCHANGE, 0, 0);
+    Application.DoEvents();
+  }
+
+  private static Prompt NewPrompt(Keys rightKey, string text) => new()
+  {
+    LeftKey = Keys.Control | Keys.Alt | Keys.Shift,
+    RightKey = rightKey,
+    Promt = text
+  };
+
+  [Fact]
+  public void AddingNewHotkey_RegistersImmediately_AndDoesNotBreakExistingHotkeys()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      var received = new List<ProcessStartDto>();
+      events.ProcessStartEvents.Subscribe(received.Add);
+
+      var promptA = NewPrompt(Keys.F13, "prompt-a");
+      var promptB = NewPrompt(Keys.F14, "prompt-b");
+      _promptRepository.AddPromptAsync(promptA).GetAwaiter().GetResult();
+      _promptRepository.AddPromptAsync(promptB).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+      using var listener = new HotKeyListener(_keyBindingState, events);
+      listener.RegisterAll();
+
+      var idA = listener.TryGetHotkeyId(promptA.Id);
+      var idB = listener.TryGetHotkeyId(promptB.Id);
+      Assert.NotNull(idA);
+      Assert.NotNull(idB);
+
+      // sanity check: both hotkeys registered at startup work before any add happens
+      PostHotkey(listener.Handle, idA.Value);
+      PostHotkey(listener.Handle, idB.Value);
+      Assert.Equal(2, received.Count);
+      Assert.Equal("prompt-a", received[0].Prompt);
+      Assert.Equal("prompt-b", received[1].Prompt);
+
+      // act: add a third prompt the same way AddPromptDialog does - a single targeted
+      // Register call, not a full Refresh()
+      var promptC = NewPrompt(Keys.F15, "prompt-c");
+      _promptRepository.AddPromptAsync(promptC).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+      listener.Register(promptC.Id, promptC.RightKey, promptC.LeftKey, promptC.Promt);
+
+      // bug #1: the new hotkey must fire immediately, with no further trigger
+      var idC = listener.TryGetHotkeyId(promptC.Id);
+      Assert.NotNull(idC);
+      PostHotkey(listener.Handle, idC.Value);
+      Assert.Equal(3, received.Count);
+      Assert.Equal("prompt-c", received[2].Prompt);
+
+      // bug #2: the previously-registered hotkeys must still work, unchanged
+      PostHotkey(listener.Handle, idA.Value);
+      PostHotkey(listener.Handle, idB.Value);
+      Assert.Equal(5, received.Count);
+      Assert.Equal("prompt-a", received[3].Prompt);
+      Assert.Equal("prompt-b", received[4].Prompt);
+
+      return true;
+    });
+  }
+
+  [Fact]
+  public void EditingHotkey_UpdatesRegistration_WithoutRestart()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      var received = new List<ProcessStartDto>();
+      events.ProcessStartEvents.Subscribe(received.Add);
+
+      var prompt = NewPrompt(Keys.F13, "before-edit");
+      _promptRepository.AddPromptAsync(prompt).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+      using var listener = new HotKeyListener(_keyBindingState, events);
+      listener.RegisterAll();
+
+      var originalId = listener.TryGetHotkeyId(prompt.Id);
+      Assert.NotNull(originalId);
+      PostHotkey(listener.Handle, originalId.Value);
+      Assert.Single(received);
+      Assert.Equal("before-edit", received[0].Prompt);
+
+      // act: edit the prompt's key binding and text, the way PromptView.ChangePromptAsync does
+      prompt.RightKey = Keys.F16;
+      prompt.Promt = "after-edit";
+      _promptRepository.UpdatePromptAsync(prompt).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+      listener.Register(prompt.Id, prompt.RightKey, prompt.LeftKey, prompt.Promt);
+
+      var updatedId = listener.TryGetHotkeyId(prompt.Id);
+      Assert.NotNull(updatedId);
+      Assert.NotEqual(originalId, updatedId);
+
+      // the old combo must no longer trigger anything
+      PostHotkey(listener.Handle, originalId.Value);
+      Assert.Single(received);
+
+      // the new combo must trigger immediately, with the updated prompt text
+      PostHotkey(listener.Handle, updatedId.Value);
+      Assert.Equal(2, received.Count);
+      Assert.Equal("after-edit", received[1].Prompt);
+
+      return true;
+    });
+  }
+
+  [Fact]
+  public void KeyboardLayoutChange_ReRegistersAllHotkeys()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      var received = new List<ProcessStartDto>();
+      events.ProcessStartEvents.Subscribe(received.Add);
+
+      var promptA = NewPrompt(Keys.F13, "prompt-a");
+      var promptB = NewPrompt(Keys.F14, "prompt-b");
+      _promptRepository.AddPromptAsync(promptA).GetAwaiter().GetResult();
+      _promptRepository.AddPromptAsync(promptB).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+      using var listener = new HotKeyListener(_keyBindingState, events);
+      listener.RegisterAll();
+
+      var originalIdA = listener.TryGetHotkeyId(promptA.Id);
+      var originalIdB = listener.TryGetHotkeyId(promptB.Id);
+      Assert.NotNull(originalIdA);
+      Assert.NotNull(originalIdB);
+
+      // act: simulate an OS keyboard layout switch
+      PostLayoutChange(listener.Handle);
+
+      // the listener must have re-registered every hotkey (new OS ids), so it recomputes
+      // the scan-code mapping under the newly active layout
+      var newIdA = listener.TryGetHotkeyId(promptA.Id);
+      var newIdB = listener.TryGetHotkeyId(promptB.Id);
+      Assert.NotNull(newIdA);
+      Assert.NotNull(newIdB);
+      Assert.NotEqual(originalIdA, newIdA);
+      Assert.NotEqual(originalIdB, newIdB);
+
+      // old ids are gone, new ids resolve to the right prompts
+      PostHotkey(listener.Handle, originalIdA.Value);
+      PostHotkey(listener.Handle, originalIdB.Value);
+      Assert.Empty(received);
+
+      PostHotkey(listener.Handle, newIdA.Value);
+      PostHotkey(listener.Handle, newIdB.Value);
+      Assert.Equal(2, received.Count);
+      Assert.Equal("prompt-a", received[0].Prompt);
+      Assert.Equal("prompt-b", received[1].Prompt);
+
+      return true;
+    });
+  }
+}

--- a/tests/TheGrammar.Tests/HotKeyListenerIntegrationTests.cs
+++ b/tests/TheGrammar.Tests/HotKeyListenerIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Microsoft.Data.Sqlite;
@@ -28,6 +29,12 @@ public class HotKeyListenerIntegrationTests : IDisposable
 
   [DllImport("user32.dll", SetLastError = true)]
   private static extern bool PostMessage(nint hWnd, int msg, nint wParam, nint lParam);
+
+  [DllImport("user32.dll", SetLastError = true)]
+  private static extern bool RegisterHotKey(nint hWnd, int id, uint fsModifiers, uint vk);
+
+  [DllImport("user32.dll", SetLastError = true)]
+  private static extern bool UnregisterHotKey(nint hWnd, int id);
 
   private readonly string _dbPath;
   private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
@@ -258,6 +265,240 @@ public class HotKeyListenerIntegrationTests : IDisposable
       Assert.Equal(2, received.Count);
       Assert.Equal("prompt-a", received[0].Prompt);
       Assert.Equal("prompt-b", received[1].Prompt);
+
+      return true;
+    });
+  }
+
+  [Fact]
+  public void EditingHotkey_WhenNewCombinationIsAlreadyTaken_KeepsOldHotkeyWorking()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      var received = new List<ProcessStartDto>();
+      events.ProcessStartEvents.Subscribe(received.Add);
+
+      var prompt = NewPrompt(Keys.F13, "before-edit");
+      _promptRepository.AddPromptAsync(prompt).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+      using var listener = new HotKeyListener(_keyBindingState, events);
+      listener.RegisterAll();
+
+      var originalId = listener.TryGetHotkeyId(prompt.Id);
+      Assert.NotNull(originalId);
+
+      // Occupy the combo we're about to move the prompt to from a separate window, so the
+      // listener's re-registration attempt genuinely fails (mirrors a real key collision)
+      // rather than being simulated.
+      const int blockerId = 999;
+      const uint modAltControlShiftNoRepeat = 0x0001 | 0x0002 | 0x0004 | 0x4000;
+      var blocker = new NativeWindow();
+      blocker.CreateHandle(new CreateParams { Caption = "hotkey-blocker" });
+
+      try
+      {
+        Assert.True(RegisterHotKey(blocker.Handle, blockerId, modAltControlShiftNoRepeat, (uint)Keys.F18));
+
+        prompt.RightKey = Keys.F18;
+        prompt.Promt = "after-edit";
+        _promptRepository.UpdatePromptAsync(prompt).GetAwaiter().GetResult();
+        _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+        // bug #3: a failed re-registration must not tear down the hotkey that was already working
+        var registered = listener.Register(prompt.Id, prompt.RightKey, prompt.LeftKey, prompt.Promt);
+        Assert.False(registered);
+
+        var idAfterFailedRegister = listener.TryGetHotkeyId(prompt.Id);
+        Assert.Equal(originalId, idAfterFailedRegister);
+
+        PostHotkey(listener.Handle, originalId.Value);
+        Assert.Single(received);
+        Assert.Equal("before-edit", received[0].Prompt);
+      }
+      finally
+      {
+        UnregisterHotKey(blocker.Handle, blockerId);
+        blocker.DestroyHandle();
+      }
+
+      return true;
+    });
+  }
+
+  [Fact]
+  public void RegisterAll_BeforeKeyBindingStateInitialized_ThrowsInsteadOfSilentlyRegisteringNothing()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      using var listener = new HotKeyListener(_keyBindingState, events);
+
+      // _keyBindingState.InitAsync() was never called - KeyBindings would silently be empty
+      Assert.Throws<InvalidOperationException>(() => listener.RegisterAll());
+
+      return true;
+    });
+  }
+
+  [Fact]
+  public void ClipboardReadFailure_DoesNotCrashListener()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      var received = new List<ProcessStartDto>();
+      events.ProcessStartEvents.Subscribe(received.Add);
+
+      var prompt = NewPrompt(Keys.F13, "prompt-a");
+      _promptRepository.AddPromptAsync(prompt).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+      using var listener = new HotKeyListener(_keyBindingState, events)
+      {
+        ClipboardTextProvider = () => throw new COMException("CLIPBRD_E_CANT_OPEN", unchecked((int)0x800401D0))
+      };
+      listener.RegisterAll();
+
+      var id = listener.TryGetHotkeyId(prompt.Id);
+      Assert.NotNull(id);
+
+      // Exercise the exact WndProc code path directly: the real OS message pump swallows
+      // exceptions that escape a window procedure in a way that can't be reliably observed
+      // from a test (see TriggerHotkey's doc comment), so we can't prove this through
+      // PostMessage/DoEvents alone.
+      var thrown = Record.Exception(() => listener.TriggerHotkey(id!.Value));
+
+      Assert.Null(thrown);
+      Assert.Empty(received);
+
+      return true;
+    });
+  }
+
+  [Fact]
+  public void EditingPromptText_WithUnchangedKeyCombination_UpdatesTextWithoutReRegistering()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      var received = new List<ProcessStartDto>();
+      events.ProcessStartEvents.Subscribe(received.Add);
+
+      var prompt = NewPrompt(Keys.F13, "before-edit");
+      _promptRepository.AddPromptAsync(prompt).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+      using var listener = new HotKeyListener(_keyBindingState, events);
+      listener.RegisterAll();
+
+      var originalId = listener.TryGetHotkeyId(prompt.Id);
+      Assert.NotNull(originalId);
+
+      // act: edit only the prompt text, keeping the same key combination - the way PromptView
+      // does when a user just tweaks the wording without touching the shortcut
+      prompt.Promt = "after-edit";
+      _promptRepository.UpdatePromptAsync(prompt).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+      // bug #4: re-registering the same combination must not fail (the old id still owns that
+      // combo, so a naive re-register-under-a-new-id would lose to it) and must pick up the new text
+      var registered = listener.Register(prompt.Id, prompt.RightKey, prompt.LeftKey, prompt.Promt);
+      Assert.True(registered);
+
+      var idAfterEdit = listener.TryGetHotkeyId(prompt.Id);
+      Assert.Equal(originalId, idAfterEdit);
+
+      PostHotkey(listener.Handle, originalId.Value);
+      Assert.Single(received);
+      Assert.Equal("after-edit", received[0].Prompt);
+
+      return true;
+    });
+  }
+
+  [Fact]
+  public void Refresh_WithACollidingCombination_DoesNotBlockOnRetries()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      var prompt = NewPrompt(Keys.F13, "prompt-a");
+      _promptRepository.AddPromptAsync(prompt).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+      using var listener = new HotKeyListener(_keyBindingState, events);
+      listener.RegisterAll();
+
+      // Occupy the prompt's combo from a separate window so Refresh's re-registration of it
+      // genuinely fails, the way a real collision after a layout switch would.
+      const int blockerId = 998;
+      const uint modAltControlShiftNoRepeat = 0x0001 | 0x0002 | 0x0004 | 0x4000;
+      var blocker = new NativeWindow();
+      blocker.CreateHandle(new CreateParams { Caption = "hotkey-blocker" });
+
+      try
+      {
+        // Refresh unregisters everything first, so this only succeeds once the listener has
+        // released its own registration for prompt-a.
+        listener.UnregisterAll();
+        Assert.True(RegisterHotKey(blocker.Handle, blockerId, modAltControlShiftNoRepeat, (uint)Keys.F13));
+
+        var stopwatch = Stopwatch.StartNew();
+        listener.Refresh();
+        stopwatch.Stop();
+
+        // bug #5: Refresh runs on the UI thread inside WndProc. A single failed attempt is
+        // near-instant; the retry path used at startup sleeps 4 x 50ms = 200ms between attempts,
+        // so a comfortably lower bound proves the retries were skipped rather than merely fast.
+        Assert.True(stopwatch.ElapsedMilliseconds < 150,
+          $"Refresh took {stopwatch.ElapsedMilliseconds}ms, expected it to skip retry sleeps entirely");
+      }
+      finally
+      {
+        UnregisterHotKey(blocker.Handle, blockerId);
+        blocker.DestroyHandle();
+      }
+
+      return true;
+    });
+  }
+
+  [Fact]
+  public void Dispose_CalledTwice_DoesNotThrow()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      var listener = new HotKeyListener(_keyBindingState, events);
+
+      listener.Dispose();
+      var thrown = Record.Exception(() => listener.Dispose());
+
+      Assert.Null(thrown);
+      return true;
+    });
+  }
+
+  [Fact]
+  public void MethodsCalledAfterDispose_ThrowObjectDisposedException()
+  {
+    RunOnSta(() =>
+    {
+      var events = new ProcessInputEventService();
+      var prompt = NewPrompt(Keys.F13, "prompt-a");
+      _promptRepository.AddPromptAsync(prompt).GetAwaiter().GetResult();
+      _keyBindingState.InitAsync().GetAwaiter().GetResult();
+
+      var listener = new HotKeyListener(_keyBindingState, events);
+      listener.Dispose();
+
+      Assert.Throws<ObjectDisposedException>(() => listener.RegisterAll());
+      Assert.Throws<ObjectDisposedException>(
+        () => listener.Register(prompt.Id, prompt.RightKey, prompt.LeftKey, prompt.Promt));
+      Assert.Throws<ObjectDisposedException>(() => listener.Refresh());
+      Assert.Throws<ObjectDisposedException>(() => listener.TriggerHotkey(1));
 
       return true;
     });

--- a/tests/TheGrammar.Tests/TheGrammar.Tests.csproj
+++ b/tests/TheGrammar.Tests/TheGrammar.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TheGrammar\TheGrammar.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Replace the wipe-and-rebuild registration model with a targeted, per-prompt-id register/replace so adding or editing one hotkey never touches any other currently-registered hotkey (new ones registered immediately, existing ones left untouched). Also handle WM_INPUTLANGCHANGE so hotkeys are re-registered when the OS keyboard layout switches, instead of staying bound to the old physical key.

Add an integration test project exercising the real RegisterHotKey/ UnregisterHotKey calls and a real SQLite db to guard against all three regressions.