### PR TITLE
#36: Add local AI inference via Foundry Local

### DIFF
--- a/src/TheGrammar/Features/Dashboard/Index.razor
+++ b/src/TheGrammar/Features/Dashboard/Index.razor
@@ -7,9 +7,9 @@
     <MudItem xs="12" sm="6" md="3">
         <MudPaper Class="d-flex flex-row pt-6 pb-4" Style="height:100px;">
             <MudIcon Icon="@Icons.Material.Filled.Psychology" Color="Color.Primary" Class="mx-4" Style="width:54px; height:54px;" />
-            <div>
+            <div style="min-width:0; overflow:hidden;">
                 <MudText Typo="Typo.subtitle1" Class="mud-text-secondary mb-n1">Model</MudText>
-                <MudText Typo="Typo.h6">@currentModel</MudText>
+                <MudText Typo="Typo.h6" Class="text-truncate" title="@currentModel">@currentModel</MudText>
             </div>
         </MudPaper>
     </MudItem>

--- a/src/TheGrammar/Features/Dashboard/Index.razor.cs
+++ b/src/TheGrammar/Features/Dashboard/Index.razor.cs
@@ -5,6 +5,7 @@ using TheGrammar.Database;
 using MudBlazor;
 using TheGrammar.Features.HotKeys.Events;
 using TheGrammar.Features.OpenAI;
+using TheGrammar.Features.PrompProcessor;
 using TheGrammar.Features.Settings;
 
 namespace TheGrammar.Features.Dashboard;
@@ -29,7 +30,9 @@ public partial class Index : IDisposable
     protected override async Task OnInitializedAsync()
     {
         subscription = IProcessInputEventService.ProcessFinishEvents.Subscribe(OnEventReceived);
-        currentModel = ChatVersionState.GetCurrentModelKey();
+        currentModel = SettingsOptionSnapshot.Value.AiProvider == AiProvider.Local
+            ? SettingsOptionSnapshot.Value.LocalModelAlias ?? "No model selected"
+            : ChatVersionState.GetCurrentModelKey();
         apiKeySet = !string.IsNullOrWhiteSpace(ApiKeyStore.Load());
         autoStartEnabled = SettingsOptionSnapshot.Value.AutoStartEnabled;
         await CountRequestAsync();

--- a/src/TheGrammar/Features/HotKeys/Services/InputProcessingManager.cs
+++ b/src/TheGrammar/Features/HotKeys/Services/InputProcessingManager.cs
@@ -8,6 +8,7 @@ using TheGrammar.Database;
 using TheGrammar.Domain;
 using TheGrammar.Features.HotKeys.Events;
 using TheGrammar.Features.OpenAI;
+using TheGrammar.Features.PrompProcessor;
 using TheGrammar.Features.Settings;
 
 namespace TheGrammar.Features.HotKeys.Services
@@ -18,21 +19,22 @@ namespace TheGrammar.Features.HotKeys.Services
     private readonly IProcessInputEventService _processService;
     private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
     private readonly ILogger<InputProcessingManager> _logger;
-    private readonly OpenAiService _openAiService;
+    private readonly AiServiceResolver _aiServiceResolver;
     private readonly CompositeDisposable _subscriptions = new();
+
 
     // Track active operations by process ID
     private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _activeOperations = new();
 
     public InputProcessingManager(
       IProcessInputEventService processService,
-      OpenAiService openAiService,
+      AiServiceResolver aiServiceResolver,
       IDbContextFactory<ApplicationDbContext> dbContextFactory,
       ILogger<InputProcessingManager> logger,
       IOptionsMonitor<SettingsOption> settingsMonitor)
     {
       _processService = processService;
-      _openAiService = openAiService;
+      _aiServiceResolver  = aiServiceResolver;
       _dbContextFactory = dbContextFactory;
       _logger = logger;
       _settingsOption = settingsMonitor.CurrentValue;
@@ -97,12 +99,12 @@ namespace TheGrammar.Features.HotKeys.Services
       }, stoppingToken);
     }
     
-    private async Task<OpenApiResult> ProcessUserInputWithCancellationAsync(ProcessStartDto dto,
+    private async Task<AiResult> ProcessUserInputWithCancellationAsync(ProcessStartDto dto,
       CancellationToken cancellationToken)
     {
       // We need to modify the OpenAiService to accept a cancellation token
-      var result = await _openAiService.ProcessAsync(dto.Prompt, dto.Input, cancellationToken).ConfigureAwait(false);
-      return result;
+      var service = _aiServiceResolver.GetCurrentService();
+      return await service.ProcessAsync(dto.Prompt, dto.Input, cancellationToken);
     }
 
     private void CancelAllActiveOperations()
@@ -146,25 +148,25 @@ namespace TheGrammar.Features.HotKeys.Services
       staThread.Join();
     }
 
-    private async Task SaveRequest(OpenApiResult openApiResult)
+    private async Task SaveRequest(AiResult aiResult)
     {
       using var context = _dbContextFactory.CreateDbContext();
       var request = new Request
       {
-        RequestText = openApiResult.OriginalText,
-        ResponseText = openApiResult.ModifiedText,
-        ModelKey = openApiResult.ModelKey
+        RequestText = aiResult.OriginalText,
+        ResponseText = aiResult.ModifiedText,
+        ModelKey = aiResult.ModelKey
       };
       context.Requests.Add(request);
       await context.SaveChangesAsync();
     }
 
-    private void SendProcessFinishNotification(OpenApiResult openApiResult)
+    private void SendProcessFinishNotification(AiResult aiResult)
     {
       var processFinishDto = new ProcessFinishDto(
-        OriginalText: openApiResult.OriginalText,
-        ModifiedText: openApiResult.ModifiedText,
-        ModelKey: openApiResult.ModelKey);
+        OriginalText: aiResult.OriginalText,
+        ModifiedText: aiResult.ModifiedText,
+        ModelKey: aiResult.ModelKey);
       _processService.TriggerProcessFinish(processFinishDto);
     }
 

--- a/src/TheGrammar/Features/LocalAI/FoundryLocalAiService.cs
+++ b/src/TheGrammar/Features/LocalAI/FoundryLocalAiService.cs
@@ -1,0 +1,25 @@
+using System.Text.RegularExpressions;
+using Betalgo.Ranul.OpenAI.ObjectModels.RequestModels;
+using TheGrammar.Features.PrompProcessor;
+
+namespace TheGrammar.Features.LocalAI;
+
+public class FoundryLocalAiService(FoundryLocalCatalogService catalogService) : IAiService
+{
+  private static readonly Regex ThinkTagsRegex = new(@"<think>[\s\S]*?</think>", RegexOptions.Compiled);
+
+  public async Task<AiResult> ProcessAsync(string prompt, string input, CancellationToken ct = default)
+  {
+    var session = await catalogService.GetChatClientForCurrentModelAsync(ct);
+
+    var response = await session.ChatClient.CompleteChatAsync([
+      new ChatMessage { Role = "system", Content = prompt },
+      new ChatMessage { Role = "user", Content = input + " /no_think" }
+    ], ct);
+
+    var content = response.Choices?[0].Message.Content ?? string.Empty;
+    var cleanContent = ThinkTagsRegex.Replace(content, "").Trim();
+
+    return new AiResult(input, cleanContent, session.Alias);
+  }
+}

--- a/src/TheGrammar/Features/LocalAI/FoundryLocalCatalogService.cs
+++ b/src/TheGrammar/Features/LocalAI/FoundryLocalCatalogService.cs
@@ -1,0 +1,109 @@
+using Microsoft.AI.Foundry.Local;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using TheGrammar.Features.Settings;
+
+namespace TheGrammar.Features.LocalAI;
+
+public record LocalModelInfo(string Alias, string DisplayName, int? FileSizeMb, bool IsCached, bool IsLoaded);
+
+public record LocalChatSession(string Alias, OpenAIChatClient ChatClient);
+
+public class FoundryLocalCatalogService(IOptionsMonitor<SettingsOption> settingsMonitor) : IDisposable
+{
+  private readonly SemaphoreSlim _initLock = new(1, 1);
+  private FoundryLocalManager? _manager;
+
+  private async Task<FoundryLocalManager> GetManagerAsync(CancellationToken ct)
+  {
+    if (_manager is not null)
+    {
+      return _manager;
+    }
+
+    await _initLock.WaitAsync(ct);
+    try
+    {
+      if (_manager is not null)
+      {
+        return _manager;
+      }
+
+      await FoundryLocalManager.CreateAsync(new Configuration { AppName = "TheGrammar" }, NullLogger.Instance, ct);
+      _manager = FoundryLocalManager.Instance;
+      return _manager;
+    }
+    finally
+    {
+      _initLock.Release();
+    }
+  }
+
+  public async Task<IReadOnlyList<LocalModelInfo>> GetCatalogModelsAsync(CancellationToken ct = default)
+  {
+    var manager = await GetManagerAsync(ct);
+    var catalog = await manager.GetCatalogAsync(ct);
+    var models = await catalog.ListModelsAsync(ct);
+
+    var result = new List<LocalModelInfo>(models.Count);
+    foreach (var model in models)
+    {
+      result.Add(new LocalModelInfo(
+        model.Alias,
+        model.Info.DisplayName,
+        model.Info.FileSizeMb,
+        await model.IsCachedAsync(ct),
+        await model.IsLoadedAsync(ct)));
+    }
+
+    return result;
+  }
+
+  public async Task DownloadAndLoadAsync(string alias, IProgress<float> progress, CancellationToken ct = default)
+  {
+    var manager = await GetManagerAsync(ct);
+    var catalog = await manager.GetCatalogAsync(ct);
+    var model = await catalog.GetModelAsync(alias, ct)
+      ?? throw new InvalidOperationException($"Model '{alias}' was not found in the Foundry Local catalog.");
+
+    foreach (var loadedModel in await catalog.GetLoadedModelsAsync(ct))
+    {
+      await loadedModel.UnloadAsync(ct);
+    }
+
+    if (!await model.IsCachedAsync(ct))
+    {
+      await model.DownloadAsync(p => progress.Report(p), ct);
+    }
+
+    await model.LoadAsync(ct);
+  }
+
+  public async Task<LocalChatSession> GetChatClientForCurrentModelAsync(CancellationToken ct = default)
+  {
+    var alias = settingsMonitor.CurrentValue.LocalModelAlias;
+    if (string.IsNullOrWhiteSpace(alias))
+    {
+      throw new InvalidOperationException("No local model selected. Choose one in Settings.");
+    }
+
+    var manager = await GetManagerAsync(ct);
+    var catalog = await manager.GetCatalogAsync(ct);
+    var model = await catalog.GetModelAsync(alias, ct)
+      ?? throw new InvalidOperationException($"Selected local model '{alias}' was not found in the Foundry Local catalog.");
+
+    if (!await model.IsLoadedAsync(ct))
+    {
+      await model.LoadAsync(ct);
+    }
+
+    var chatClient = await model.GetChatClientAsync(ct);
+    return new LocalChatSession(alias, chatClient);
+  }
+
+  public void Dispose()
+  {
+    _manager?.Dispose();
+    _initLock.Dispose();
+  }
+}

--- a/src/TheGrammar/Features/OpenAI/OpenAiServiceAdapter.cs
+++ b/src/TheGrammar/Features/OpenAI/OpenAiServiceAdapter.cs
@@ -1,0 +1,13 @@
+﻿using TheGrammar.Features.HotKeys;
+using TheGrammar.Features.PrompProcessor;
+
+namespace TheGrammar.Features.OpenAI;
+
+public class OpenAiServiceAdapter(OpenAiService openAiService) : IAiService
+{
+  public async Task<AiResult> ProcessAsync(string prompt, string input, CancellationToken ct = default)
+  {
+    var result = await openAiService.ProcessAsync(prompt, input, ct);
+    return new AiResult(result.OriginalText, result.ModifiedText, result.ModelKey);
+  }
+}

--- a/src/TheGrammar/Features/PrompProcessor/IAiService.cs
+++ b/src/TheGrammar/Features/PrompProcessor/IAiService.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Extensions.Options;
+using TheGrammar.Features.LocalAI;
+using TheGrammar.Features.OpenAI;
+using TheGrammar.Features.Settings;
+
+namespace TheGrammar.Features.PrompProcessor;
+
+public interface IAiService
+{
+  Task<AiResult> ProcessAsync(string prompt, string input, CancellationToken ct = default);
+}
+
+public record AiResult(
+  string OriginalText,
+  string ModifiedText,
+  string ModelKey);
+  
+public enum AiProvider
+{
+  OpenAi,
+  Local
+}
+
+public class AiServiceResolver
+{
+  private readonly IAiService _openAiService;
+  private readonly IAiService _localAiService;
+  private readonly IOptionsMonitor<SettingsOption> _settingsMonitor;
+
+  public AiServiceResolver(
+    OpenAiServiceAdapter openAiAdapter,
+    FoundryLocalAiService foundryLocalService,
+    IOptionsMonitor<SettingsOption> settingsMonitor)
+    : this((IAiService)openAiAdapter, (IAiService)foundryLocalService, settingsMonitor)
+  {
+  }
+
+  internal AiServiceResolver(IAiService openAiService, IAiService localAiService, IOptionsMonitor<SettingsOption> settingsMonitor)
+  {
+    _openAiService = openAiService;
+    _localAiService = localAiService;
+    _settingsMonitor = settingsMonitor;
+  }
+
+  public IAiService GetCurrentService()
+  {
+    return _settingsMonitor.CurrentValue.AiProvider == AiProvider.Local
+      ? _localAiService
+      : _openAiService;
+  }
+}

--- a/src/TheGrammar/Features/Settings/Components/AddLocalModelDialog.razor
+++ b/src/TheGrammar/Features/Settings/Components/AddLocalModelDialog.razor
@@ -1,0 +1,28 @@
+<MudDialog>
+    <DialogContent>
+        @if (_isLoadingCatalog)
+        {
+            <MudProgressCircular Indeterminate="true" />
+        }
+        else
+        {
+            <MudSelect T="string" Label="Model" HelperText="Select a model from the Foundry Local catalog" @bind-Value="_selectedAlias" Style="width: 100%;">
+                @foreach (var model in _catalogModels)
+                {
+                    <MudSelectItem Value="@model.Alias">@model.DisplayName@(model.IsCached ? " (downloaded)" : "")</MudSelectItem>
+                }
+            </MudSelect>
+        }
+
+        @if (_isDownloading)
+        {
+            <MudProgressLinear Value="_downloadProgress" Color="Color.Primary" Class="mt-4" />
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit" Disabled="@(_isDownloading || string.IsNullOrEmpty(_selectedAlias))">
+            Download &amp; Use
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/TheGrammar/Features/Settings/Components/AddLocalModelDialog.razor.cs
+++ b/src/TheGrammar/Features/Settings/Components/AddLocalModelDialog.razor.cs
@@ -1,0 +1,72 @@
+using DialogResult = MudBlazor.DialogResult;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using TheGrammar.Features.LocalAI;
+
+namespace TheGrammar.Features.Settings.Components;
+
+public partial class AddLocalModelDialog
+{
+    private IReadOnlyList<LocalModelInfo> _catalogModels = [];
+    private string? _selectedAlias;
+    private bool _isLoadingCatalog = true;
+    private bool _isDownloading;
+    private double _downloadProgress;
+
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [Inject] public FoundryLocalCatalogService LocalCatalogService { get; set; } = null!;
+    [Inject] public ISnackbar Snackbar { get; set; } = null!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _catalogModels = await LocalCatalogService.GetCatalogModelsAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to load the Foundry Local catalog: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isLoadingCatalog = false;
+        }
+    }
+
+    async Task Submit()
+    {
+        if (string.IsNullOrEmpty(_selectedAlias))
+        {
+            return;
+        }
+
+        _isDownloading = true;
+        _downloadProgress = 0;
+        StateHasChanged();
+
+        try
+        {
+            var progress = new Progress<float>(p =>
+            {
+                _downloadProgress = p;
+                InvokeAsync(StateHasChanged);
+            });
+
+            await LocalCatalogService.DownloadAndLoadAsync(_selectedAlias, progress);
+
+            SettingsOption.UpdateSettings(nameof(SettingsOption.LocalModelAlias), _selectedAlias);
+            MudDialog!.Close(DialogResult.Ok(true));
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to download/load model: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isDownloading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/src/TheGrammar/Features/Settings/DependencyInjection.cs
+++ b/src/TheGrammar/Features/Settings/DependencyInjection.cs
@@ -1,5 +1,9 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using TheGrammar.Features.HotKeys;
+using TheGrammar.Features.LocalAI;
+using TheGrammar.Features.OpenAI;
+using TheGrammar.Features.PrompProcessor;
 
 namespace TheGrammar.Features.Settings;
 
@@ -8,6 +12,12 @@ public static class DependencyInjection
     public static IServiceCollection AddSettings(this IServiceCollection services, IConfiguration configuration)
     {
         services.Configure<SettingsOption>(configuration.GetSection(SettingsOption.SectionName));
+        
+        services.AddSingleton<OpenAiServiceAdapter>();
+        services.AddSingleton<FoundryLocalCatalogService>();
+        services.AddSingleton<FoundryLocalAiService>();
+        services.AddSingleton<AiServiceResolver>();
+        
         return services;
     }
 }

--- a/src/TheGrammar/Features/Settings/Settings.razor
+++ b/src/TheGrammar/Features/Settings/Settings.razor
@@ -1,9 +1,63 @@
 @page "/settings"
+@using TheGrammar.Features.HotKeys
+@using TheGrammar.Features.PrompProcessor
+@using TheGrammar.Features.LocalAI
+@using TheGrammar.Features.Settings.Components
 
 <MudText Typo="Typo.h6" Style="padding-bottom: 25px">Settings</MudText>
 
 <div style="display: flex; flex-direction: column; gap: 20px;">
 
+        <MudCard>
+        <MudCardHeader>
+            <CardHeaderContent>
+                <MudText Typo="Typo.subtitle1">AI Provider</MudText>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudRadioGroup T="AiProvider" Value="_settingsOption.AiProvider" ValueChanged="OnAiProviderChanged">
+                <MudRadio Value="AiProvider.OpenAi" Color="Color.Primary">OpenAI (Cloud)</MudRadio>
+                <MudRadio Value="AiProvider.Local" Color="Color.Primary">Foundry Local</MudRadio>
+            </MudRadioGroup>
+        </MudCardContent>
+    </MudCard>
+    @if (_settingsOption.AiProvider == AiProvider.Local)
+    {
+        <MudCard>
+            <MudCardHeader>
+                <CardHeaderContent>
+                    <MudText Typo="Typo.subtitle1">Foundry Local</MudText>
+                </CardHeaderContent>
+            </MudCardHeader>
+            <MudCardContent Style="display: flex; flex-direction: column; gap: 10px;">
+                <div style="display: flex; align-items: flex-end; gap: 10px;">
+                    <MudSelect T="string"
+                               Label="Model"
+                               HelperText="@(_cachedLocalModels.Count == 0 ? "No models downloaded yet - click + to add one" : "Select a downloaded model")"
+                               Value="_settingsOption.LocalModelAlias"
+                               ValueChanged="OnSelectedLocalModelChanged"
+                               Disabled="@_isRefreshingLocalModel"
+                               Style="flex: 1">
+                        @foreach (var model in _cachedLocalModels)
+                        {
+                            <MudSelectItem Value="@model.Alias">@model.DisplayName</MudSelectItem>
+                        }
+                    </MudSelect>
+                    <MudIconButton Icon="@Icons.Material.Filled.Add" OnClick="AddLocalModel" Title="Add local model" />
+                </div>
+                @if (_isRefreshingLocalModel)
+                {
+                    <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                }
+                else if (_selectedLocalModel is not null)
+                {
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary">
+                        Status: @(_selectedLocalModel.IsLoaded ? "Loaded" : "Downloaded")
+                    </MudText>
+                }
+            </MudCardContent>
+        </MudCard>
+    }
     <MudCard>
         <MudCardHeader>
             <CardHeaderContent>
@@ -39,7 +93,6 @@
             <MudButton Variant="Variant.Filled" OnClick="SaveOpenAiClickHandler" StartIcon="@Icons.Material.Filled.Save" IconColor="Color.Primary" Size="Size.Large">@(_isEditingApiKey ? "Save & Restart" : "Save")</MudButton>
         </MudCardActions>
     </MudCard>
-
     <MudCard>
         <MudCardHeader>
             <CardHeaderContent>

--- a/src/TheGrammar/Features/Settings/Settings.razor.cs
+++ b/src/TheGrammar/Features/Settings/Settings.razor.cs
@@ -3,6 +3,9 @@ using Microsoft.Extensions.Options;
 using TheGrammar.Features.OpenAI;
 using TheGrammar.Features.Settings.Components;
 using MudBlazor;
+using TheGrammar.Features.HotKeys;
+using TheGrammar.Features.LocalAI;
+using TheGrammar.Features.PrompProcessor;
 
 namespace TheGrammar.Features.Settings;
 
@@ -12,6 +15,9 @@ public partial class Settings
   private string _newApiKey = string.Empty;
   private bool _isEditingApiKey;
   private SettingsOption _settingsOption = new();
+  private LocalModelInfo? _selectedLocalModel;
+  private IReadOnlyList<LocalModelInfo> _cachedLocalModels = [];
+  private bool _isRefreshingLocalModel;
 
   private string MaskedApiKey => _apiKey.Length > 4
     ? new string('•', _apiKey.Length - 4) + _apiKey[^4..]
@@ -35,11 +41,17 @@ public partial class Settings
   [Inject] public ChatVersionState ChatVersionState { get; set; } = null!;
   [Inject] public IDialogService DialogService { get; set; } = null!;
   [Inject] public ModelRepository ModelRepository { get; set; } = null!;
+  [Inject] public FoundryLocalCatalogService LocalCatalogService { get; set; } = null!;
 
   protected override void OnInitialized()
   {
     _apiKey = ApiKeyStore.Load() ?? string.Empty;
     _settingsOption = SettingsOptionSnapshot.Value;
+
+    if (_settingsOption.AiProvider == AiProvider.Local)
+    {
+      _ = RefreshLocalModelsAsync();
+    }
 
     StateHasChanged();
     base.OnInitialized();
@@ -107,6 +119,79 @@ public partial class Settings
   {
     _settingsOption.PlaySoundOnProcessStart = shouldPlaySoundOnProcessStart;
     SettingsOption.UpdateSettings(nameof(SettingsOption.PlaySoundOnProcessStart), shouldPlaySoundOnProcessStart);
+  }
+
+  public void OnAiProviderChanged(AiProvider provider)
+  {
+    _settingsOption.AiProvider = provider;
+    SettingsOption.UpdateSettings(nameof(SettingsOption.AiProvider), provider.ToString());
+
+    if (provider == AiProvider.Local)
+    {
+      _ = RefreshLocalModelsAsync();
+    }
+  }
+
+  private async Task RefreshLocalModelsAsync()
+  {
+    _isRefreshingLocalModel = true;
+    StateHasChanged();
+
+    try
+    {
+      var models = await LocalCatalogService.GetCatalogModelsAsync();
+      _cachedLocalModels = models.Where(m => m.IsCached).ToList();
+
+      var alias = _settingsOption.LocalModelAlias;
+      _selectedLocalModel = !string.IsNullOrWhiteSpace(alias)
+        ? models.FirstOrDefault(m => m.Alias == alias)
+        : null;
+    }
+    finally
+    {
+      _isRefreshingLocalModel = false;
+      StateHasChanged();
+    }
+  }
+
+  public async Task OnSelectedLocalModelChanged(string alias)
+  {
+    if (string.IsNullOrEmpty(alias))
+    {
+      return;
+    }
+
+    _isRefreshingLocalModel = true;
+    StateHasChanged();
+
+    try
+    {
+      await LocalCatalogService.DownloadAndLoadAsync(alias, new Progress<float>());
+      SettingsOption.UpdateSettings(nameof(SettingsOption.LocalModelAlias), alias);
+      _settingsOption.LocalModelAlias = alias;
+      await RefreshLocalModelsAsync();
+    }
+    catch (Exception ex)
+    {
+      Snackbar.Add($"Failed to select model: {ex.Message}", Severity.Error);
+    }
+    finally
+    {
+      _isRefreshingLocalModel = false;
+      StateHasChanged();
+    }
+  }
+
+  public async Task AddLocalModel()
+  {
+    var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+    var dialogReference = await DialogService.ShowAsync<AddLocalModelDialog>("Add Local Model", options);
+    var result = await dialogReference.Result;
+
+    if (result is { Canceled: false, Data: true })
+    {
+      await RefreshLocalModelsAsync();
+    }
   }
 
   public void OnAddAsteriskAtTheEndOfResponseChanged(bool shouldAddAsteriskAtTheEndOfResponse)

--- a/src/TheGrammar/Features/Settings/SettingsOption.cs
+++ b/src/TheGrammar/Features/Settings/SettingsOption.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.Json.Nodes;
+using System.Text.Json.Nodes;
 using System.Text.Json;
+using TheGrammar.Features.HotKeys;
+using TheGrammar.Features.PrompProcessor;
 
 namespace TheGrammar.Features.Settings;
 
@@ -10,8 +12,14 @@ public class SettingsOption
     public bool AutoStartEnabled { get; set; }
     public bool PlaySoundOnProcessStart { get; set; }
     public bool AddAsteriskAtTheEndOfResponse { get; set; }
+    public AiProvider AiProvider { get; set; } = AiProvider.OpenAi;
+    public string? LocalModelAlias { get; set; }
 
-    public static void UpdateSettings(string propertyName, bool value)
+    public static void UpdateSettings(string propertyName, bool value) => UpdateSettingsInternal(propertyName, value);
+
+    public static void UpdateSettings(string propertyName, string value) => UpdateSettingsInternal(propertyName, value);
+
+    private static void UpdateSettingsInternal(string propertyName, JsonNode? value)
     {
         var appSettingsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
 

--- a/src/TheGrammar/MainForm.Designer.cs
+++ b/src/TheGrammar/MainForm.Designer.cs
@@ -36,7 +36,7 @@
             blazorWebView1.Dock = DockStyle.Fill;
             blazorWebView1.Location = new Point(0, 0);
             blazorWebView1.Name = "blazorWebView1";
-            blazorWebView1.Size = new Size(1150, 850);
+            blazorWebView1.Size = new Size(1600, 950);
             blazorWebView1.TabIndex = 6;
             blazorWebView1.Text = "blazorWebView1";
             // 
@@ -44,7 +44,7 @@
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(1150, 850);
+            ClientSize = new Size(1600, 950);
             Controls.Add(blazorWebView1);
             Icon = (Icon)resources.GetObject("$this.Icon");
             MaximizeBox = false;

--- a/src/TheGrammar/TheGrammar.csproj
+++ b/src/TheGrammar/TheGrammar.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	 <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TheGrammar/TheGrammar.csproj
+++ b/src/TheGrammar/TheGrammar.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Clowd.Squirrel" Version="2.11.1" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.17" />
+    <PackageReference Include="Microsoft.AI.Foundry.Local" Version="1.2.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="10.0.51" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
@@ -29,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageReference Include="OpenAI" Version="2.9.1" />
+    <PackageReference Include="Betalgo.Ranul.OpenAI" Version="9.1.0" />
 	<PackageReference Include="MudBlazor" Version="9.2.0" />
 	<PackageReference Include="Serilog" Version="4.3.1" />
 	<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/tests/TheGrammar.Tests/AiServiceResolverTests.cs
+++ b/tests/TheGrammar.Tests/AiServiceResolverTests.cs
@@ -1,0 +1,43 @@
+using TheGrammar.Features.PrompProcessor;
+using TheGrammar.Features.Settings;
+
+namespace TheGrammar.Tests;
+
+public class AiServiceResolverTests
+{
+  private sealed class StubAiService : IAiService
+  {
+    public Task<AiResult> ProcessAsync(string prompt, string input, CancellationToken ct = default)
+      => throw new NotSupportedException("Not used by resolver tests");
+  }
+
+  [Fact]
+  public void GetCurrentService_ReturnsOpenAiService_WhenProviderIsOpenAi()
+  {
+    var openAi = new StubAiService();
+    var local = new StubAiService();
+    var resolver = new AiServiceResolver(
+      openAi,
+      local,
+      new TestOptionsMonitor<SettingsOption>(new SettingsOption { AiProvider = AiProvider.OpenAi }));
+
+    var result = resolver.GetCurrentService();
+
+    Assert.Same(openAi, result);
+  }
+
+  [Fact]
+  public void GetCurrentService_ReturnsLocalService_WhenProviderIsLocal()
+  {
+    var openAi = new StubAiService();
+    var local = new StubAiService();
+    var resolver = new AiServiceResolver(
+      openAi,
+      local,
+      new TestOptionsMonitor<SettingsOption>(new SettingsOption { AiProvider = AiProvider.Local }));
+
+    var result = resolver.GetCurrentService();
+
+    Assert.Same(local, result);
+  }
+}

--- a/tests/TheGrammar.Tests/FoundryLocalCatalogServiceTests.cs
+++ b/tests/TheGrammar.Tests/FoundryLocalCatalogServiceTests.cs
@@ -1,0 +1,18 @@
+using TheGrammar.Features.LocalAI;
+using TheGrammar.Features.Settings;
+
+namespace TheGrammar.Tests;
+
+public class FoundryLocalCatalogServiceTests
+{
+  [Fact]
+  public async Task GetChatClientForCurrentModelAsync_Throws_WhenNoAliasConfigured()
+  {
+    var service = new FoundryLocalCatalogService(
+      new TestOptionsMonitor<SettingsOption>(new SettingsOption { LocalModelAlias = null }));
+
+    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetChatClientForCurrentModelAsync());
+
+    Assert.Contains("Settings", ex.Message);
+  }
+}

--- a/tests/TheGrammar.Tests/TestOptionsMonitor.cs
+++ b/tests/TheGrammar.Tests/TestOptionsMonitor.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Options;
+
+namespace TheGrammar.Tests;
+
+internal sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T> where T : class
+{
+  public T CurrentValue { get; } = value;
+
+  public T Get(string? name) => CurrentValue;
+
+  public IDisposable OnChange(Action<T, string?> listener) => null!;
+}

--- a/tests/TheGrammar.Tests/TheGrammar.Tests.csproj
+++ b/tests/TheGrammar.Tests/TheGrammar.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Fixes the non-compiling Foundry Local sketch and replaces the two competing provider switches (UseLocalAi bool + unused AiProvider enum) with a single AiProvider-based strategy, mirrored by FoundryLocalCatalogService wrapping the real Microsoft.AI.Foundry.Local SDK. Settings gets a Foundry Local card with a model picker for already-downloaded models plus a catalog browser dialog to download new ones, and the Dashboard's model tile now reflects whichever provider is actually active.